### PR TITLE
CI: Do not run on push to mainline

### DIFF
--- a/.github/workflows/pre-commit.yml
+++ b/.github/workflows/pre-commit.yml
@@ -4,8 +4,6 @@ name: pre-commit
 # yamllint disable:line rule:truthy
 on:
   pull_request:
-  push:
-    branches: [master, main]
 
 jobs:
   pre-commit:


### PR DESCRIPTION
Merging PRs into mainline causes pre-commit to throw an error since that
is a pre-commit protected branch. As we do not push directly to mainline
this is ok to not check

Signed-off-by: Andrew Grimberg <tykeal@bardicgrove.org>