### PR TITLE
Style: Add editoconfig and remove in editor lines

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,30 @@
+root = true
+
+[*]
+end_of_line = lf
+insert_final_newline = true
+trim_trailing_whitespace = true
+indent_style = space
+
+[*.json]
+indent_size = 2
+
+[*.md]
+indent_size = 4
+max_line_length = 80
+
+[*.pp]
+indent_size = 2
+
+[*.rb]
+indent_size = 2
+
+[*.rst]
+indent_size = 4
+
+[*.sh]
+indent_size = 4
+max_line_length = 80
+
+[*.yaml]
+indent_size = 2

--- a/spec/classes/init_spec.rb
+++ b/spec/classes/init_spec.rb
@@ -80,5 +80,3 @@ describe 'external_facts' do
     }
   end
 end
-
-# vim: ts=2 sw=2 sts=2 et :

--- a/spec/classes/params_spec.rb
+++ b/spec/classes/params_spec.rb
@@ -12,5 +12,3 @@ describe 'external_facts::params' do
     it { is_expected.to contain_class('external_facts::params') }
   end
 end
-
-# vim: ts=2 sw=2 sts=2 et :

--- a/spec/defines/fact_spec.rb
+++ b/spec/defines/fact_spec.rb
@@ -29,5 +29,3 @@ describe 'external_facts::fact' do
     }
   end
 end
-
-# vim: ts=2 sw=2 sts=2 et :


### PR DESCRIPTION
The editorconfig-vim plugin should be used by anyone using vim.

Remove the vim specific config lines from files (two have been left in
place to force certain syntax)

Signed-off-by: Andrew Grimberg <tykeal@bardicgrove.org>